### PR TITLE
Changed default log.sqlite3 directory to be more semantic.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -234,7 +234,7 @@ DiaryDB can be used in a context manager.
 **Initialization**
    ``class DiaryDB(path)``
 
-* path *str* path of database to use
+* path *str* path of database to use. If no path is passed and the python command was invoked normally, it will look for a file named 'log.sqlite3' in the root folder of your application. In some edge cases when python programs aren't invoked through the process interface, you will need to pass a custom path even if 'log.sqlite3' is in the root folder of the application.
 
 **Fields** *(Not listed above)*
 

--- a/diary/logdb.py
+++ b/diary/logdb.py
@@ -69,10 +69,6 @@ class DiaryDB(object):
         except sqlite3.ProgrammingError:
             pass
 
-    def destroy(self):
-        """Destroy the SQLite database file."""
-        os.remove(self.path)
-
     def __enter__(self):
         return self
 

--- a/diary/logdb.py
+++ b/diary/logdb.py
@@ -18,12 +18,12 @@ class DiaryDB(object):
         """
         if path is None:
             if sys.argv[0]:
-                self.path = os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])))
+                self.path = os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), 'log.sqlite3')
             else:
                 self.path = 'log.sqlite3'
         else:
             self.path = path
-        self.conn = sqlite3.connect(path, detect_types=sqlite3.PARSE_DECLTYPES)
+        self.conn = sqlite3.connect(self.path, detect_types=sqlite3.PARSE_DECLTYPES)
         self.cursor = self.conn.cursor()
         self.create_tables()
 
@@ -68,6 +68,10 @@ class DiaryDB(object):
             self.conn.close()
         except sqlite3.ProgrammingError:
             pass
+
+    def destroy(self):
+        """Destroy the SQLite database file."""
+        os.remove(self.path)
 
     def __enter__(self):
         return self

--- a/diary/logdb.py
+++ b/diary/logdb.py
@@ -1,4 +1,5 @@
 import sqlite3
+import os, sys
 
 
 class DiaryDB(object):
@@ -10,12 +11,18 @@ class DiaryDB(object):
     to log. DiaryDB uses SQLite3.
     """
 
-    def __init__(self, path='log.sqlite3'):
+    def __init__(self, path=None):
         """
         Create the connection with the database and attempt to make a table.
         :param path: relative path of database
         """
-        self.path = path
+        if path is None:
+            if sys.argv[0]:
+                self.path = os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])))
+            else:
+                self.path = 'log.sqlite3'
+        else:
+            self.path = path
         self.conn = sqlite3.connect(path, detect_types=sqlite3.PARSE_DECLTYPES)
         self.cursor = self.conn.cursor()
         self.create_tables()

--- a/tests/command_test.py
+++ b/tests/command_test.py
@@ -1,4 +1,4 @@
-import os
+import os, sys
 import unittest
 
 
@@ -9,7 +9,7 @@ class SqliteTest(unittest.TestCase):
         command = 'diary generate sqlite %s/log.sqlite3' % self.TESTING_DIR
         os.system(command)
 
-        self.assertTrue(os.path.exists(os.path.join(self.TESTING_DIR, 'log.sqlite3')))
+        self.assertTrue(os.path.exists(os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), 'log.sqlite3')))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/command_test.py
+++ b/tests/command_test.py
@@ -5,7 +5,7 @@ import unittest
 class SqliteTest(unittest.TestCase):
     TESTING_DIR = os.path.join(os.path.dirname(__file__), 'testing_dir')
 
-    def test_command(self):
+    def test_command_and_logdb_defaults(self):
         command = 'diary generate sqlite %s/log.sqlite3' % self.TESTING_DIR
         os.system(command)
 

--- a/tests/logdb_test.py
+++ b/tests/logdb_test.py
@@ -11,6 +11,7 @@ class TestDiaryDB(unittest.TestCase):
 
     def setUp(self):
         self.logdb = DiaryDB(self.TEMP_DB_PATH)
+        self.logdb_default = DiaryDB()
 
     @classmethod
     def tearDownClass(cls):
@@ -49,7 +50,6 @@ class TestDiaryDB(unittest.TestCase):
             self.logdb.conn.execute("SELECT 1 FROM logs LIMIT 1")
 
     def test_default_path(self):
-        self.logdb_default = DiaryDB()
         self.logdb_default.log(self.SIMPLE_EVENT)
         entry = self.logdb_default.cursor.execute('''SELECT * FROM logs ORDER BY
                                              inputDT ASC LIMIT 1''').fetchone()

--- a/tests/logdb_test.py
+++ b/tests/logdb_test.py
@@ -58,9 +58,5 @@ class TestDiaryDB(unittest.TestCase):
         self.assertEquals(entry[2], self.SIMPLE_EVENT.info)
         self.logdb_default.close()
 
-    def test_logdb_destroy(self):
-        self.logdb_default.destroy()
-        self.assertTrue(not os.path.exists(self.logdb_default.path))
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/logdb_test.py
+++ b/tests/logdb_test.py
@@ -48,5 +48,19 @@ class TestDiaryDB(unittest.TestCase):
                                msg="Cannot operate on a closed database."):
             self.logdb.conn.execute("SELECT 1 FROM logs LIMIT 1")
 
+    def test_default_path(self):
+        self.logdb_default = DiaryDB()
+        self.logdb_default.log(self.SIMPLE_EVENT)
+        entry = self.logdb_default.cursor.execute('''SELECT * FROM logs ORDER BY
+                                             inputDT ASC LIMIT 1''').fetchone()
+        self.assertEquals(entry[0], self.SIMPLE_EVENT.dt)
+        self.assertEquals(entry[1], self.SIMPLE_EVENT.level)
+        self.assertEquals(entry[2], self.SIMPLE_EVENT.info)
+        self.logdb_default.close()
+
+    def test_logdb_destroy(self):
+        self.logdb_default.destroy()
+        self.assertTrue(not os.path.exists(self.logdb_default.path))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The default path for the sqlite 3 log file has been changed to be in the root directory of the user's application, when none is provided.
